### PR TITLE
Fix clock showing Error

### DIFF
--- a/ETime_body.php
+++ b/ETime_body.php
@@ -33,7 +33,7 @@ class ETime
 
 		$client = new Client();
 
-		$response = $client->request('GET', 'https://armeagle.atitd.org/tabtime.php');
+		$response = $client->request('GET', 'https://atitd.sharpnetwork.net/gameclock/tabtime.asp');
 
 		$raw = $response->getBody()->getContents();
 


### PR DESCRIPTION
https://armeagle.atitd.org/tabtime.php returns Error, while https://atitd.sharpnetwork.net/gameclock/tabtime.asp returns the correct response.

Perhaps a better solution is to directly use ArmEagle's clock code instead of relying on an API request. I'm not sure where that PHP code is, but Cegaiel has a solid ASP and JavaScript implementation that could be ported back to PHP.